### PR TITLE
Optionally log objects instead of messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,24 @@ foo(function(err, result) {
 
 ## `timeMe.configure`
 
-Globally configure the module.
+Globally configure the module on what log function to use. Defaults to
+`console.log`
 
 ```javascript
 timeMe.configure({
-
-    // The logging function to use for output.
-    // Defaults to `console.log`.
-    log: function(msg) { // do logging here }
-
-    // If `true`, in addition to a string, the `log()` function
-    // will be passed an object of the form:
-    // ```
-    // {
-    //     prefix: string // prefix message
-    //     elapsed: number // elapsed time in milliseconds
-    // }
-    // ```
-    // defaults to `false`
-    logObject: false
+    log: function(msg, obj) { // do logging here }
 });
 ```
+
+The configured logging function will be passed two arguments:
+1. A string containing the message used to name the call, and the call time.
+2. An object containing the same information, of the form
+   ```javascript
+   {
+       prefix: string // prefix message
+       elapsed: number // elapsed time in milliseconds
+   }
+   ```
 
 ## `timeMe.async`
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Globally configure the module.
 ```javascript
 timeMe.configure({
 
-	// The logging function to use for output.
-	// Defaults to `console.log`.
+    // The logging function to use for output.
+    // Defaults to `console.log`.
     log: function(msg) { // do logging here }
 
-    // If `true`, instead of a string, the `log()` function will be passed
-    // an object of the form:
+    // If `true`, in addition to a string, the `log()` function
+    // will be passed an object of the form:
     // ```
     // {
     //     prefix: string // prefix message
@@ -83,5 +83,3 @@ Turn logs on or off. Defaults to `false` (meaning logging on).
 
 Whenever a wrapped function is called, additionally to logging the time, a property will
 be set on the function: `lastTime`. You can query the function for the property.
-
-

--- a/README.md
+++ b/README.md
@@ -30,12 +30,25 @@ foo(function(err, result) {
 
 ## `timeMe.configure`
 
-Globally configure the module on what log function to use. Defaults to
-`console.log`
+Globally configure the module.
 
 ```javascript
 timeMe.configure({
+
+	// The logging function to use for output.
+	// Defaults to `console.log`.
     log: function(msg) { // do logging here }
+
+    // If `true`, instead of a string, the `log()` function will be passed
+    // an object of the form:
+    // ```
+    // {
+    //     prefix: string // prefix message
+    //     elapsed: number // elapsed time in milliseconds
+    // }
+    // ```
+    // defaults to `false`
+    logObject: false
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var HRStopwatch = require('hrstopwatch')
 exports.configure = function(options) {
     options = options || {};
     log = options.log;
-    logObject = !!options.logObject || false
+    logObject = !!options.logObject || false;
 }
 
 exports.async = function(options, fn) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var HRStopwatch = require('hrstopwatch')
 , timeunit = require ('timeunit')
 , log = console.log
+, logObject = false
 , DEFAULT_PREFIX = "timeMe";
 
 /*
@@ -11,6 +12,7 @@ var HRStopwatch = require('hrstopwatch')
 exports.configure = function(options) {
     options = options || {};
     log = options.log;
+    logObject = !!options.logObject || false
 }
 
 exports.async = function(options, fn) {
@@ -19,6 +21,16 @@ exports.async = function(options, fn) {
 
 exports.sync = function(options, fn) {
     return timeMe(false, options, fn);
+}
+
+function logMsg(options, msg, elapsed) {
+    if (!options.noLog) {
+        if (logObject) {
+            log({msg: msg, elapsed: elapsed});
+        } else {
+            log(msg + " " + elapsed + "ms");
+        }
+    }
 }
 
 /*
@@ -67,7 +79,7 @@ function timeMe(async, options, fn) {
             result = fn.apply(this, arguments);
             elapsed = getTime(watch);
             __timee__.lastTime = elapsed;
-            if (!options.noLog) log(msg + " " + elapsed + "ms");
+            logMsg(options, msg, elapsed);
             return result;
         }
     }
@@ -81,7 +93,7 @@ function getInjector(options, cb) {
     return function() {
         var elapsed = getTime(options.watch);
         options.__timee__.lastTime = elapsed;
-        if (!options.noLog) log(options.msg + " " + elapsed + "ms");
+        logMsg(options, options.msg, elapsed);
         cb.apply(this, arguments);
     }
 }

--- a/index.js
+++ b/index.js
@@ -24,11 +24,12 @@ exports.sync = function(options, fn) {
 }
 
 function logMsg(options, msg, elapsed) {
+    logStr = msg + " " + elapsed + "ms";
     if (!options.noLog) {
         if (logObject) {
-            log({prefix: msg, elapsed: elapsed});
+            log(logStr, {prefix: msg, elapsed: elapsed});
         } else {
-            log(msg + " " + elapsed + "ms");
+            log(logStr);
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var HRStopwatch = require('hrstopwatch')
 , timeunit = require ('timeunit')
 , log = console.log
-, logObject = false
 , DEFAULT_PREFIX = "timeMe";
 
 /*
@@ -12,7 +11,6 @@ var HRStopwatch = require('hrstopwatch')
 exports.configure = function(options) {
     options = options || {};
     log = options.log;
-    logObject = !!options.logObject || false;
 }
 
 exports.async = function(options, fn) {
@@ -24,13 +22,8 @@ exports.sync = function(options, fn) {
 }
 
 function logMsg(options, msg, elapsed) {
-    logStr = msg + " " + elapsed + "ms";
     if (!options.noLog) {
-        if (logObject) {
-            log(logStr, {prefix: msg, elapsed: elapsed});
-        } else {
-            log(logStr);
-        }
+        log(msg + " " + elapsed + "ms", {prefix: msg, elapsed: elapsed});
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ exports.sync = function(options, fn) {
 function logMsg(options, msg, elapsed) {
     if (!options.noLog) {
         if (logObject) {
-            log({msg: msg, elapsed: elapsed});
+            log({prefix: msg, elapsed: elapsed});
         } else {
             log(msg + " " + elapsed + "ms");
         }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "coffee-script": "^1.9.1",
     "mocha": "^2.2.1",
     "sinon": "^1.13.0",
-    "streamline": "^0.10.17"
+    "streamline": "^0.10.17",
+    "lodash": "^3.9.3"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "time-me",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Time a block of code with minimal effort.",
   "main": "index.js",
   "dependencies": {
@@ -36,7 +36,8 @@
     "url": "benbria.com"
   },
   "contributors": [
-    "Calvin Wiebe <calvin.wiebe@gmail.com> (https://github.com/calvinwiebe)"
+    "Calvin Wiebe <calvin.wiebe@gmail.com> (https://github.com/calvinwiebe)",
+    "Bernard Llanos (https://github.com/bllanos)"
   ],
   "license": "MIT"
 }

--- a/test/async.js
+++ b/test/async.js
@@ -1,107 +1,121 @@
 var expect = require('chai').expect
 , timeMe = require('../')
-, sinon  = require('sinon');
+, sinon  = require('sinon')
+, stubLogger = require('./utils').stubLogger;
 
-describe('async', function() {
+var logObjectValues = [true, false];
 
-    beforeEach(function() {
-        timeMe.configure({log: console.log});
-    });
+logObjectValues.forEach( function(logObject) {
 
-    describe('argument acception', function() {
+    describe('async, logObject = ' + logObject, function() {
 
-        it('(msg, cb)', function(done) {
-            var t = Math.lOOms(),
-            foo = timeMe.async('foo()', function(cb) {
-                setTimeout(function() {
-                    cb(null, '25');
-                }, t);
+        beforeEach(function() {
+            stubLogger.attach({logObject: logObject});
+        });
+
+        describe('argument acception, logObject = ' + logObject, function() {
+
+            it('(msg, cb)', function(done) {
+                var msg = 'foo()';
+                stubLogger.setMsg(msg);
+                var t = Math.lOOms(),
+                foo = timeMe.async(msg, function(cb) {
+                    setTimeout(function() {
+                        cb(null, '25');
+                    }, t);
+                });
+                foo.call(null, function() {
+                    expect(foo.lastTime).to.be.at.least(t);
+                    done();
+                });
             });
-            foo.call(null, function() {
-                expect(foo.lastTime).to.be.at.least(t);
-                done();
+
+            it('({msg, index}, cb)', function(done) {
+                var msg = 'bar()';
+                stubLogger.setMsg(msg);
+                var t = Math.lOOms(),
+                bar = timeMe.async({msg: msg, index: 1}, function(x, cb, y) {
+                    setTimeout(function() {
+                        cb(null, x + y);
+                    }, t);
+                });
+                bar.call(null, 1, function(err, result) {
+                    expect(result).to.eq(3);
+                    expect(bar.lastTime).to.be.at.least(t);
+                    done();
+                }, 2);
+            });
+
+            it('({msg, index, noLog:1}, cb) - log not called', function(done) {
+                var t = Math.lOOms(),
+                spy = sinon.spy(),
+                dontLogMe = timeMe.async({
+                    msg: 'dontLogMe()',
+                    noLog: 1,
+                }, function(cb) {
+                    setTimeout(function() {
+                        cb(null, 1);
+                    }, t);
+                });
+                timeMe.configure({log: spy, logObject: logObject});
+                dontLogMe.call(null, function(err, result) {
+                    expect(spy.called).to.not.be.ok;
+                    expect(dontLogMe.lastTime).to.be.at.least(t);
+                    done();
+                });
+            });
+
+            it('(cb)', function(done) {
+                var msg = 'timeMe';
+                stubLogger.setMsg(msg);
+                var t = Math.lOOms(),
+                baz = timeMe.async(function(cb) {
+                    setTimeout(function() {
+                        cb(null, 1);
+                    }, t);
+                });
+                baz.call(null, function(err, result) {
+                    expect(baz.lastTime).to.be.at.least(t);
+                    done();
+                });
+            });
+
+            it('({}, cb) - default log message', function(done) {
+                var t = Math.lOOms();
+                timeMe.configure({log: function(msg) {
+                    expect(/timeMe/.test(msg)).to.be.ok;
+                }});
+                var baz = timeMe.async({}, function(cb) {
+                    setTimeout(function() {
+                        cb(null, 1);
+                    }, t);
+                });
+                baz.call(null, function(err, result) {
+                    expect(baz.lastTime).to.be.at.least(t);
+                    done();
+                });
             });
         });
 
-        it('({msg, index}, cb)', function(done) {
-            var t = Math.lOOms(),
-            bar = timeMe.async({msg: 'bar()', index: 1}, function(x, cb, y) {
-                setTimeout(function() {
-                    cb(null, x + y);
-                }, t);
+        describe('keep the calling context, logObject = ' + logObject, function() {
+            it('should keep the context of this', function(done) {
+                var msg = 'foo()';
+                stubLogger.setMsg(msg);
+                var t = Math.lOOms(),
+                foo = timeMe.async(msg, function(cb) {
+                    var self = this;
+                    setTimeout(function() {
+                        cb.call(self, null, '25');
+                    }, t);
+                });
+                foo.call({x: 1}, function(err, result) {
+                    expect(this.x).to.equal(1);
+                    expect(foo.lastTime).to.be.at.least(t);
+                    done();
+                });
             });
-            bar.call(null, 1, function(err, result) {
-                expect(result).to.eq(3);
-                expect(bar.lastTime).to.be.at.least(t);
-                done();
-            }, 2);
         });
+    })
 
-        it('({msg, index, noLog:1}, cb) - log not called', function(done) {
-            var t = Math.lOOms(),
-            spy = sinon.spy(),
-            dontLogMe = timeMe.async({
-                msg: 'dontLogMe()',
-                noLog: 1,
-                log: spy
-            }, function(cb) {
-                setTimeout(function() {
-                    cb(null, 1);
-                }, t);
-            });
-            timeMe.configure({log: spy});
-            dontLogMe.call(null, function(err, result) {
-                expect(spy.called).to.not.be.ok;
-                expect(dontLogMe.lastTime).to.be.at.least(t);
-                done();
-            });
-        });
-
-        it('(cb)', function(done) {
-            var t = Math.lOOms(),
-            baz = timeMe.async(function(cb) {
-                setTimeout(function() {
-                    cb(null, 1);
-                }, t);
-            });
-            baz.call(null, function(err, result) {
-                expect(baz.lastTime).to.be.at.least(t);
-                done();
-            });
-        });
-
-        it('({}, cb) - default log message', function(done) {
-            var t = Math.lOOms();
-            timeMe.configure({log: function(msg) {
-                expect(/timeMe/.test(msg)).to.be.ok;
-            }});
-            var baz = timeMe.async({}, function(cb) {
-                setTimeout(function() {
-                    cb(null, 1);
-                }, t);
-            });
-            baz.call(null, function(err, result) {
-                expect(baz.lastTime).to.be.at.least(t);
-                done();
-            });
-        });
-    });
-
-    describe('keep the calling context', function() {
-        it('should keep the context of this', function(done) {
-            var t = Math.lOOms(),
-            foo = timeMe.async('foo()', function(cb) {
-                var self = this;
-                setTimeout(function() {
-                    cb.call(self, null, '25');
-                }, t);
-            });
-            foo.call({x: 1}, function(err, result) {
-                expect(this.x).to.equal(1);
-                expect(foo.lastTime).to.be.at.least(t);
-                done();
-            });
-        });
-    });
-})
+});
 

--- a/test/async.js
+++ b/test/async.js
@@ -3,119 +3,112 @@ var expect = require('chai').expect
 , sinon  = require('sinon')
 , stubLogger = require('./utils').stubLogger;
 
-var logObjectValues = [true, false];
+describe('async', function() {
 
-logObjectValues.forEach( function(logObject) {
+    beforeEach(function() {
+        stubLogger.attach();
+    });
 
-    describe('async, logObject = ' + logObject, function() {
+    describe('argument acception', function() {
 
-        beforeEach(function() {
-            stubLogger.attach({logObject: logObject});
-        });
-
-        describe('argument acception, logObject = ' + logObject, function() {
-
-            it('(msg, cb)', function(done) {
-                var msg = 'foo()';
-                stubLogger.setMsg(msg);
-                var t = Math.lOOms(),
-                foo = timeMe.async(msg, function(cb) {
-                    setTimeout(function() {
-                        cb(null, '25');
-                    }, t);
-                });
-                foo.call(null, function() {
-                    expect(foo.lastTime).to.be.at.least(t);
-                    done();
-                });
+        it('(msg, cb)', function(done) {
+            var msg = 'foo()';
+            stubLogger.setMsg(msg);
+            var t = Math.lOOms(),
+            foo = timeMe.async(msg, function(cb) {
+                setTimeout(function() {
+                    cb(null, '25');
+                }, t);
             });
-
-            it('({msg, index}, cb)', function(done) {
-                var msg = 'bar()';
-                stubLogger.setMsg(msg);
-                var t = Math.lOOms(),
-                bar = timeMe.async({msg: msg, index: 1}, function(x, cb, y) {
-                    setTimeout(function() {
-                        cb(null, x + y);
-                    }, t);
-                });
-                bar.call(null, 1, function(err, result) {
-                    expect(result).to.eq(3);
-                    expect(bar.lastTime).to.be.at.least(t);
-                    done();
-                }, 2);
-            });
-
-            it('({msg, index, noLog:1}, cb) - log not called', function(done) {
-                var t = Math.lOOms(),
-                spy = sinon.spy(),
-                dontLogMe = timeMe.async({
-                    msg: 'dontLogMe()',
-                    noLog: 1,
-                }, function(cb) {
-                    setTimeout(function() {
-                        cb(null, 1);
-                    }, t);
-                });
-                timeMe.configure({log: spy, logObject: logObject});
-                dontLogMe.call(null, function(err, result) {
-                    expect(spy.called).to.not.be.ok;
-                    expect(dontLogMe.lastTime).to.be.at.least(t);
-                    done();
-                });
-            });
-
-            it('(cb)', function(done) {
-                var msg = 'timeMe';
-                stubLogger.setMsg(msg);
-                var t = Math.lOOms(),
-                baz = timeMe.async(function(cb) {
-                    setTimeout(function() {
-                        cb(null, 1);
-                    }, t);
-                });
-                baz.call(null, function(err, result) {
-                    expect(baz.lastTime).to.be.at.least(t);
-                    done();
-                });
-            });
-
-            it('({}, cb) - default log message', function(done) {
-                var t = Math.lOOms();
-                timeMe.configure({log: function(msg) {
-                    expect(/timeMe/.test(msg)).to.be.ok;
-                }});
-                var baz = timeMe.async({}, function(cb) {
-                    setTimeout(function() {
-                        cb(null, 1);
-                    }, t);
-                });
-                baz.call(null, function(err, result) {
-                    expect(baz.lastTime).to.be.at.least(t);
-                    done();
-                });
+            foo.call(null, function() {
+                expect(foo.lastTime).to.be.at.least(t);
+                done();
             });
         });
 
-        describe('keep the calling context, logObject = ' + logObject, function() {
-            it('should keep the context of this', function(done) {
-                var msg = 'foo()';
-                stubLogger.setMsg(msg);
-                var t = Math.lOOms(),
-                foo = timeMe.async(msg, function(cb) {
-                    var self = this;
-                    setTimeout(function() {
-                        cb.call(self, null, '25');
-                    }, t);
-                });
-                foo.call({x: 1}, function(err, result) {
-                    expect(this.x).to.equal(1);
-                    expect(foo.lastTime).to.be.at.least(t);
-                    done();
-                });
+        it('({msg, index}, cb)', function(done) {
+            var msg = 'bar()';
+            stubLogger.setMsg(msg);
+            var t = Math.lOOms(),
+            bar = timeMe.async({msg: msg, index: 1}, function(x, cb, y) {
+                setTimeout(function() {
+                    cb(null, x + y);
+                }, t);
+            });
+            bar.call(null, 1, function(err, result) {
+                expect(result).to.eq(3);
+                expect(bar.lastTime).to.be.at.least(t);
+                done();
+            }, 2);
+        });
+
+        it('({msg, index, noLog:1}, cb) - log not called', function(done) {
+            var t = Math.lOOms(),
+            spy = sinon.spy(),
+            dontLogMe = timeMe.async({
+                msg: 'dontLogMe()',
+                noLog: 1,
+            }, function(cb) {
+                setTimeout(function() {
+                    cb(null, 1);
+                }, t);
+            });
+            timeMe.configure({log: spy});
+            dontLogMe.call(null, function(err, result) {
+                expect(spy.called).to.not.be.ok;
+                expect(dontLogMe.lastTime).to.be.at.least(t);
+                done();
             });
         });
-    })
 
-});
+        it('(cb)', function(done) {
+            var msg = 'timeMe';
+            stubLogger.setMsg(msg);
+            var t = Math.lOOms(),
+            baz = timeMe.async(function(cb) {
+                setTimeout(function() {
+                    cb(null, 1);
+                }, t);
+            });
+            baz.call(null, function(err, result) {
+                expect(baz.lastTime).to.be.at.least(t);
+                done();
+            });
+        });
 
+        it('({}, cb) - default log message', function(done) {
+            var t = Math.lOOms();
+            timeMe.configure({log: function(msg) {
+                expect(/timeMe/.test(msg)).to.be.ok;
+            }});
+            var baz = timeMe.async({}, function(cb) {
+                setTimeout(function() {
+                    cb(null, 1);
+                }, t);
+            });
+            baz.call(null, function(err, result) {
+                expect(baz.lastTime).to.be.at.least(t);
+                done();
+            });
+        });
+    });
+
+    describe('keep the calling context', function() {
+        it('should keep the context of this', function(done) {
+            var msg = 'foo()';
+            stubLogger.setMsg(msg);
+            var t = Math.lOOms(),
+            foo = timeMe.async(msg, function(cb) {
+                var self = this;
+                setTimeout(function() {
+                    cb.call(self, null, '25');
+                }, t);
+            });
+            foo.call({x: 1}, function(err, result) {
+                expect(this.x).to.equal(1);
+                expect(foo.lastTime).to.be.at.least(t);
+                done();
+            });
+        });
+    });
+})

--- a/test/sync.js
+++ b/test/sync.js
@@ -1,20 +1,33 @@
 var expect = require('chai').expect
 , timeMe = require('../')
-, sinon  = require('sinon');
+, sinon  = require('sinon')
+, stubLogger = require('./utils').stubLogger;
 
-describe('sync', function() {
-    it('should time a sync function', function() {
-        baz = timeMe.sync('baz()', function(x) {
-            var a = [];
-            for(var i=0; i < 100000; i++) {
-                a.push(i);
-            }
-            a.map(function(elem) {
-                return "The number is " + elem;
-            });
-            return a.join(",");
+var logObjectValues = [true, false];
+
+logObjectValues.forEach( function(logObject) {
+
+    describe('sync, logObject = ' + logObject, function() {
+
+        beforeEach(function() {
+            stubLogger.attach({logObject: logObject});
         });
-        var result = baz.call(null, 1);
-        expect(baz.lastTime).to.be.ok;
+
+        it('should time a sync function', function() {
+            var msg = 'baz()';
+            stubLogger.setMsg(msg);
+            baz = timeMe.sync(msg, function(x) {
+                var a = [];
+                for(var i=0; i < 100000; i++) {
+                    a.push(i);
+                }
+                a.map(function(elem) {
+                    return "The number is " + elem;
+                });
+                return a.join(",");
+            });
+            var result = baz.call(null, 1);
+            expect(baz.lastTime).to.be.ok;
+        });
     });
 });

--- a/test/sync.js
+++ b/test/sync.js
@@ -3,31 +3,26 @@ var expect = require('chai').expect
 , sinon  = require('sinon')
 , stubLogger = require('./utils').stubLogger;
 
-var logObjectValues = [true, false];
+describe('sync', function() {
 
-logObjectValues.forEach( function(logObject) {
+    beforeEach(function() {
+        stubLogger.attach();
+    });
 
-    describe('sync, logObject = ' + logObject, function() {
-
-        beforeEach(function() {
-            stubLogger.attach({logObject: logObject});
-        });
-
-        it('should time a sync function', function() {
-            var msg = 'baz()';
-            stubLogger.setMsg(msg);
-            baz = timeMe.sync(msg, function(x) {
-                var a = [];
-                for(var i=0; i < 100000; i++) {
-                    a.push(i);
-                }
-                a.map(function(elem) {
-                    return "The number is " + elem;
-                });
-                return a.join(",");
+    it('should time a sync function', function() {
+        var msg = 'baz()';
+        stubLogger.setMsg(msg);
+        baz = timeMe.sync(msg, function(x) {
+            var a = [];
+            for(var i=0; i < 100000; i++) {
+                a.push(i);
+            }
+            a.map(function(elem) {
+                return "The number is " + elem;
             });
-            var result = baz.call(null, 1);
-            expect(baz.lastTime).to.be.ok;
+            return a.join(",");
         });
+        var result = baz.call(null, 1);
+        expect(baz.lastTime).to.be.ok;
     });
 });

--- a/test/transpilers._coffee
+++ b/test/transpilers._coffee
@@ -1,36 +1,46 @@
 {expect} = require 'chai'
 timeMe   = require '../'
+stubLogger = require('./utils').stubLogger
 
-describe 'async - coffee and streamline', ->
-    describe 'coffee', ->
-        it 'should work with coffee', (done) ->
-            t = Math.lOOms()
-            foo = timeMe.async (cb) ->
-                setTimeout ->
-                    cb null, 2
-                , t
-            foo (err, result) ->
-                expect(result).to.equal(2)
+logObjectValues = [true, false]
+
+logObjectValues.forEach (logObject) ->
+
+    describe "async - coffee and streamline, logObject = #{logObject}", ->
+
+        beforeEach ->
+            stubLogger.attach {logObject}
+            stubLogger.setMsg 'timeMe'
+
+        describe 'coffee', ->
+            it 'should work with coffee', (done) ->
+                t = Math.lOOms()
+                foo = timeMe.async (cb) ->
+                    setTimeout ->
+                        cb null, 2
+                    , t
+                foo (err, result) ->
+                    expect(result).to.equal(2)
+                    expect(foo.lastTime).to.be.at.least(t)
+                    done()
+
+        describe 'streamline', ->
+            it 'should work with streamline', (_) ->
+                t = Math.lOOms()
+                foo = timeMe.async (a, b, c, _) ->
+                    setTimeout _, t
+                    return a + b + c
+
+                res = foo 1, 2, 3, _
+                expect(res).to.equal(6)
                 expect(foo.lastTime).to.be.at.least(t)
-                done()
 
-    describe 'streamline', ->
-        it 'should work with streamline', (_) ->
-            t = Math.lOOms()
-            foo = timeMe.async (a, b, c, _) ->
-                setTimeout _, t
-                return a + b + c
+            it 'should work with streamline cb in a different position than last', (_) ->
+                t = Math.lOOms()
+                foo = timeMe.async {index: 1}, (a, _, b, c) ->
+                    setTimeout _, t
+                    return a + b + c
 
-            res = foo 1, 2, 3, _
-            expect(res).to.equal(6)
-            expect(foo.lastTime).to.be.at.least(t)
-
-        it 'should work with streamline cb in a different position than last', (_) ->
-            t = Math.lOOms()
-            foo = timeMe.async {index: 1}, (a, _, b, c) ->
-                setTimeout _, t
-                return a + b + c
-
-            res = foo 1, _, 2, 3
-            expect(res).to.equal(6)
-            expect(foo.lastTime).to.be.at.least(t)
+                res = foo 1, _, 2, 3
+                expect(res).to.equal(6)
+                expect(foo.lastTime).to.be.at.least(t)

--- a/test/transpilers._coffee
+++ b/test/transpilers._coffee
@@ -2,45 +2,41 @@
 timeMe   = require '../'
 stubLogger = require('./utils').stubLogger
 
-logObjectValues = [true, false]
+describe 'async - coffee and streamline', ->
 
-logObjectValues.forEach (logObject) ->
+    beforeEach ->
+        stubLogger.attach()
+        stubLogger.setMsg 'timeMe'
 
-    describe "async - coffee and streamline, logObject = #{logObject}", ->
-
-        beforeEach ->
-            stubLogger.attach {logObject}
-            stubLogger.setMsg 'timeMe'
-
-        describe 'coffee', ->
-            it 'should work with coffee', (done) ->
-                t = Math.lOOms()
-                foo = timeMe.async (cb) ->
-                    setTimeout ->
-                        cb null, 2
-                    , t
-                foo (err, result) ->
-                    expect(result).to.equal(2)
-                    expect(foo.lastTime).to.be.at.least(t)
-                    done()
-
-        describe 'streamline', ->
-            it 'should work with streamline', (_) ->
-                t = Math.lOOms()
-                foo = timeMe.async (a, b, c, _) ->
-                    setTimeout _, t
-                    return a + b + c
-
-                res = foo 1, 2, 3, _
-                expect(res).to.equal(6)
+    describe 'coffee', ->
+        it 'should work with coffee', (done) ->
+            t = Math.lOOms()
+            foo = timeMe.async (cb) ->
+                setTimeout ->
+                    cb null, 2
+                , t
+            foo (err, result) ->
+                expect(result).to.equal(2)
                 expect(foo.lastTime).to.be.at.least(t)
+                done()
 
-            it 'should work with streamline cb in a different position than last', (_) ->
-                t = Math.lOOms()
-                foo = timeMe.async {index: 1}, (a, _, b, c) ->
-                    setTimeout _, t
-                    return a + b + c
+    describe 'streamline', ->
+        it 'should work with streamline', (_) ->
+            t = Math.lOOms()
+            foo = timeMe.async (a, b, c, _) ->
+                setTimeout _, t
+                return a + b + c
 
-                res = foo 1, _, 2, 3
-                expect(res).to.equal(6)
-                expect(foo.lastTime).to.be.at.least(t)
+            res = foo 1, 2, 3, _
+            expect(res).to.equal(6)
+            expect(foo.lastTime).to.be.at.least(t)
+
+        it 'should work with streamline cb in a different position than last', (_) ->
+            t = Math.lOOms()
+            foo = timeMe.async {index: 1}, (a, _, b, c) ->
+                setTimeout _, t
+                return a + b + c
+
+            res = foo 1, _, 2, 3
+            expect(res).to.equal(6)
+            expect(foo.lastTime).to.be.at.least(t)

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -10,36 +10,42 @@ Math.lOOms = function() {
 }
 
 exports.stubLogger = function() {
-	var msg = null;
+    var msg = null;
 
-	return {
-		setMsg: function(newMsg) {
-			msg = newMsg;
-		},
+    return {
+        setMsg: function(newMsg) {
+            msg = newMsg;
+        },
 
-		attach: function(options) {
-			var logObject = options.logObject || false;
+        attach: function(options) {
+            var logObject = options.logObject || false;
             timeMe.configure(ld.assign({}, options, {
-                log: function(arg) {
-                    var prefix, elapsed;
-                    expect(arguments).to.have.length(1);
+                log: function(str, obj) {
+                    var prefix = [], elapsed = [];
+
                     if (logObject === true) {
-                        expect(arg).to.be.a('object');
-                        prefix = arg.prefix;
-                        elapsed = arg.elapsed;
+                        expect(arguments).to.have.length(2);
+                        expect(obj).to.be.a('object');
+                        prefix.push(obj.prefix);
+                        elapsed.push(obj.elapsed);
                     } else {
-                        expect(arg).to.be.a('string');
-                        var msgParts = arg.split(' ');
-                        var timeStr = msgParts[msgParts.length - 1];
-                        elapsed = parseInt(timeStr.slice(0, -2));
-                        prefix = msgParts.slice(0, -1).join(' ');
+                        expect(arguments).to.have.length(1);
                     }
-                    expect(prefix).to.eql(msg);
-                    expect(elapsed).to.be.a('number');
-                    expect(elapsed).to.be.at.least(0);
+
+                    expect(str).to.be.a('string');
+                    var msgParts = str.split(' ');
+                    var timeStr = msgParts[msgParts.length - 1];
+                    elapsed.push(parseInt(timeStr.slice(0, -2)));
+                    prefix.push(msgParts.slice(0, -1).join(' '));
+
+                    for(var i = 0; i < arguments.length; ++i) {
+                        expect(prefix[i]).to.eql(msg);
+                        expect(elapsed[i]).to.be.a('number');
+                        expect(elapsed[i]).to.be.at.least(0);
+                    }
                 }
             }
             ));
-		}
-	};
+        }
+    };
 }();

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,6 +1,45 @@
+var expect = require('chai').expect
+, timeMe = require('../../')
+, ld = require('lodash');
+
 /*
 * Give a random time under 100
 */
 Math.lOOms = function() {
     return parseInt(Math.random() * 100);
 }
+
+exports.stubLogger = function() {
+	var msg = null;
+
+	return {
+		setMsg: function(newMsg) {
+			msg = newMsg;
+		},
+
+		attach: function(options) {
+			var logObject = options.logObject || false;
+            timeMe.configure(ld.assign({}, options, {
+                log: function(arg) {
+                    var prefix, elapsed;
+                    expect(arguments).to.have.length(1);
+                    if (logObject === true) {
+                        expect(arg).to.be.a('object');
+                        prefix = arg.msg;
+                        elapsed = arg.elapsed;
+                    } else {
+                        expect(arg).to.be.a('string');
+                        var msgParts = arg.split(' ');
+                        var timeStr = msgParts[msgParts.length - 1];
+                        elapsed = parseInt(timeStr.slice(0, -2));
+                        prefix = msgParts.slice(0, -1).join(' ');
+                    }
+                    expect(prefix).to.eql(msg);
+                    expect(elapsed).to.be.a('number');
+                    expect(elapsed).to.be.at.least(0);
+                }
+            }
+            ));
+		}
+	};
+}();

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -25,7 +25,7 @@ exports.stubLogger = function() {
                     expect(arguments).to.have.length(1);
                     if (logObject === true) {
                         expect(arg).to.be.a('object');
-                        prefix = arg.msg;
+                        prefix = arg.prefix;
                         elapsed = arg.elapsed;
                     } else {
                         expect(arg).to.be.a('string');

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -18,19 +18,14 @@ exports.stubLogger = function() {
         },
 
         attach: function(options) {
-            var logObject = options.logObject || false;
             timeMe.configure(ld.assign({}, options, {
                 log: function(str, obj) {
                     var prefix = [], elapsed = [];
-
-                    if (logObject === true) {
-                        expect(arguments).to.have.length(2);
-                        expect(obj).to.be.a('object');
-                        prefix.push(obj.prefix);
-                        elapsed.push(obj.elapsed);
-                    } else {
-                        expect(arguments).to.have.length(1);
-                    }
+                    expect(arguments).to.have.length(2);
+                    
+                    expect(obj).to.be.a('object');
+                    prefix.push(obj.prefix);
+                    elapsed.push(obj.elapsed);
 
                     expect(str).to.be.a('string');
                     var msgParts = str.split(' ');

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -9,6 +9,18 @@ Math.lOOms = function() {
     return parseInt(Math.random() * 100);
 }
 
+/*
+* The `attach()` method of the returned object
+* configures the time-me module to use a stub
+* logging function that validates the arguments
+* it is called on.
+*
+* Aside from checking the types and structures
+* of its arguments, the stub logger also ensures
+* that the correct prefix is being logged.
+* For this to work, it must know what prefix is expected.
+* The client must set this using the `setMsg()` method.
+*/
 exports.stubLogger = function() {
     var msg = null;
 
@@ -22,7 +34,7 @@ exports.stubLogger = function() {
                 log: function(str, obj) {
                     var prefix = [], elapsed = [];
                     expect(arguments).to.have.length(2);
-                    
+
                     expect(obj).to.be.a('object');
                     prefix.push(obj.prefix);
                     elapsed.push(obj.elapsed);


### PR DESCRIPTION
Requested reviewers: @calvinwiebe 

### Changes

- Added a new `logObject` option to the configuration function.
- When true, `time-me` will output a `{prefix, elapsed}` object instead of a string version of the same information.

### Testing Performed
- Updated unit tests to run twice - Once for each value of the `logObject` configuration parameter.